### PR TITLE
Add launch in azurenb

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Some of them can be executed in a basic numpy / scipy / pandas / matplotlib / sc
 environment for instance using:
 
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/ogrisel/notebooks)
+<a href="https://notebooks.azure.com/import/gh/ogrisel/notebooks"><img src="https://notebooks.azure.com/launch.png" /></a>


### PR DESCRIPTION
Adding a link to README.md that makes it easy for users to launch this repository in Azure Notebooks.

I work on Azure Notebooks and wanted to help users launch your content on our platform. It is a free service for executing Jupyter Notebook.